### PR TITLE
Fix case when not properly considering missing xmp entry

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosInfo.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosInfo.java
@@ -211,11 +211,14 @@ public class GFCosInfo extends GFCosDict implements CosInfo {
             }
         }
         String creationDate = getCreationDate();
-        if (xmpCreateDate != null && creationDate != null) {
+        if (creationDate == null) {
+            return null;
+        }
+        if (xmpCreateDate != null) {
             Calendar creationDateCalendar = TypeConverter.parseDate(creationDate);
             return creationDateCalendar != null && xmpCreateDate.compareTo(creationDateCalendar) == 0;
         }
-        return null;
+        return false;
     }
 
     @Override
@@ -228,11 +231,14 @@ public class GFCosInfo extends GFCosDict implements CosInfo {
             }
         }
         String modDate = getModDate();
-        if (xmpModifyDate != null && modDate != null) {
+        if (modDate == null) {
+            return null;
+        }
+        if (xmpModifyDate != null) {
             Calendar modDateCalendar = TypeConverter.parseDate(modDate);
             return modDateCalendar != null && xmpModifyDate.compareTo(modDateCalendar) == 0;
         }
-        return null;
+        return false;
     }
 
     @Override

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosInfo.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/cos/GFCosInfo.java
@@ -203,16 +203,16 @@ public class GFCosInfo extends GFCosDict implements CosInfo {
 
     @Override
     public Boolean getdoCreationDatesMatch() {
+        String creationDate = getCreationDate();
+        if (creationDate == null) {
+            return null;
+        }
         Calendar xmpCreateDate = null;
         if (meta != null) {
             try {
                 xmpCreateDate = meta.getCreateDate();
             } catch (XMPException ignored) {
             }
-        }
-        String creationDate = getCreationDate();
-        if (creationDate == null) {
-            return null;
         }
         if (xmpCreateDate != null) {
             Calendar creationDateCalendar = TypeConverter.parseDate(creationDate);
@@ -223,16 +223,16 @@ public class GFCosInfo extends GFCosDict implements CosInfo {
 
     @Override
     public Boolean getdoModDatesMatch() {
+        String modDate = getModDate();
+        if (modDate == null) {
+            return null;
+        }
         Calendar xmpModifyDate = null;
         if (meta != null) {
             try {
                 xmpModifyDate = meta.getModifyDate();
             } catch (XMPException ignored) {
             }
-        }
-        String modDate = getModDate();
-        if (modDate == null) {
-            return null;
         }
         if (xmpModifyDate != null) {
             Calendar modDateCalendar = TypeConverter.parseDate(modDate);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Date-field validation now correctly handles mismatches between PDF metadata sources: when a creation or modification date is present in one metadata format but absent in the other, the validator reports the mismatch rather than treating it as unknown. This improves accuracy and reduces false/ambiguous validation outcomes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->