### PR TITLE
Fix glyph width calculation and Remove extra spaces

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -837,7 +837,7 @@ public class ChunkParser {
 				}
 			}
             double threshold = graphicsState.getTextState().getTextFontSize() * TextChunkUtils.TEXT_LINE_SPACE_RATIO;
-            textPieces.addSpacesByShift(threshold);
+            textPieces.addSpaces(threshold);
 
 			unicodeValue.append(textPieces.getValue());
 			if (!textPieces.isEmpty()) {

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -832,15 +832,28 @@ public class ChunkParser {
 						double shift = - obj.getReal() / 1000 *
 								graphicsState.getTextState().getTextFontSize() *
 								graphicsState.getTextState().getHorizontalScaling();
-						if (-obj.getReal() >= TextChunkUtils.TEXT_CHUNK_SPACE_RATIO && StaticStorages.getIsAddSpacesBetweenTextPieces()) {
-							textPieces.add(new TextPieces.TextPiece(" ", textPieces.getCurrentX(),
-									textPieces.getCurrentX() + shift));
-						} else {
-							textPieces.shiftCurrentX(shift);
-						}
+                        textPieces.shiftCurrentX(shift);
 					}
 				}
 			}
+            double previousEnd = 0;
+            double currentStart = 0;
+            List<TextPieces.TextPiece> spaces = new ArrayList<>();
+            for (TextPieces.TextPiece textPiece: textPieces.getTextPieces()) {
+                if (textPiece.equals(textPieces.getTextPieces().first())) {
+                    previousEnd = textPiece.getEndX();
+                    continue;
+                }
+                currentStart = textPiece.getStartX();
+                if (currentStart - previousEnd > graphicsState.getTextState().getTextFontSize() * TextChunkUtils.TEXT_LINE_SPACE_RATIO) {
+                    spaces.add(new TextPieces.TextPiece(" ", previousEnd,
+                            currentStart));
+                }
+                previousEnd = textPiece.getEndX();
+            }
+            for (TextPieces.TextPiece space: spaces) {
+                textPieces.add(space);
+            }
 			unicodeValue.append(textPieces.getValue());
 			if (!textPieces.isEmpty()) {
 				textMatrix.concatenate(Matrix.getTranslateInstance(textPieces.getStartX(), 0));
@@ -867,17 +880,18 @@ public class ChunkParser {
 							" in font" + graphicsState.getTextState().getTextFont().getName());
 					width = 0.0;
 				}
-				double shift = (width *
-								graphicsState.getTextState().getTextFontSize() / 1000 +
-								graphicsState.getTextState().getCharacterSpacing() + (code == 32 ?
+				double shift = (graphicsState.getTextState().getCharacterSpacing() + (code == 32 ?
 								graphicsState.getTextState().getWordSpacing() : 0)) *
 								graphicsState.getTextState().getHorizontalScaling();
-				String value = graphicsState.getTextState().getTextFont().toUnicode(code);
+                width = width *
+                        graphicsState.getTextState().getTextFontSize() / 1000 *
+                        graphicsState.getTextState().getHorizontalScaling();
+                String value = graphicsState.getTextState().getTextFont().toUnicode(code);
 				if (symbolEnds != null) {
 					if (symbolEnds.isEmpty()) {
-						TextChunksHelper.updateSymbolEnds(symbolEnds, shift, 0, value != null ? value.length() : 0);
+						TextChunksHelper.updateSymbolEnds(symbolEnds,  width, 0, value != null ? value.length() : 0);
 					} else {
-						TextChunksHelper.updateSymbolEnds(symbolEnds, shift, symbolEnds.get(symbolEnds.size() - 1),
+						TextChunksHelper.updateSymbolEnds(symbolEnds,  width, symbolEnds.get(symbolEnds.size() - 1),
 						                                  value != null ? value.length() : 0);
 					}
 				}
@@ -892,7 +906,8 @@ public class ChunkParser {
 					unicodeValue.append(result);
 				} else {
 					textPieces.add(new TextPieces.TextPiece(result, textPieces.getCurrentX(),
-					                                        textPieces.getCurrentX() + shift));
+					                                        textPieces.getCurrentX() + width));
+                    textPieces.shiftCurrentX(shift);
 				}
 			}
 		} catch (IOException e) {

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -836,24 +836,9 @@ public class ChunkParser {
 					}
 				}
 			}
-            double previousEnd = 0;
-            double currentStart = 0;
-            List<TextPieces.TextPiece> spaces = new ArrayList<>();
-            for (TextPieces.TextPiece textPiece: textPieces.getTextPieces()) {
-                if (textPiece.equals(textPieces.getTextPieces().first())) {
-                    previousEnd = textPiece.getEndX();
-                    continue;
-                }
-                currentStart = textPiece.getStartX();
-                if (currentStart - previousEnd > graphicsState.getTextState().getTextFontSize() * TextChunkUtils.TEXT_LINE_SPACE_RATIO) {
-                    spaces.add(new TextPieces.TextPiece(" ", previousEnd,
-                            currentStart));
-                }
-                previousEnd = textPiece.getEndX();
-            }
-            for (TextPieces.TextPiece space: spaces) {
-                textPieces.add(space);
-            }
+            double threshold = graphicsState.getTextState().getTextFontSize() * TextChunkUtils.TEXT_LINE_SPACE_RATIO;
+            textPieces.addSpacesByShift(threshold);
+
 			unicodeValue.append(textPieces.getValue());
 			if (!textPieces.isEmpty()) {
 				textMatrix.concatenate(Matrix.getTranslateInstance(textPieces.getStartX(), 0));
@@ -889,9 +874,9 @@ public class ChunkParser {
                 String value = graphicsState.getTextState().getTextFont().toUnicode(code);
 				if (symbolEnds != null) {
 					if (symbolEnds.isEmpty()) {
-						TextChunksHelper.updateSymbolEnds(symbolEnds,  width, 0, value != null ? value.length() : 0);
+						TextChunksHelper.updateSymbolEnds(symbolEnds, shift + width, 0, value != null ? value.length() : 0);
 					} else {
-						TextChunksHelper.updateSymbolEnds(symbolEnds,  width, symbolEnds.get(symbolEnds.size() - 1),
+						TextChunksHelper.updateSymbolEnds(symbolEnds, shift + width, symbolEnds.get(symbolEnds.size() - 1),
 						                                  value != null ? value.length() : 0);
 					}
 				}
@@ -906,7 +891,7 @@ public class ChunkParser {
 					unicodeValue.append(result);
 				} else {
 					textPieces.add(new TextPieces.TextPiece(result, textPieces.getCurrentX(),
-					                                        textPieces.getCurrentX() + width));
+					                                        textPieces.getCurrentX() + shift + width));
                     textPieces.shiftCurrentX(shift);
 				}
 			}

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -891,7 +891,7 @@ public class ChunkParser {
 					unicodeValue.append(result);
 				} else {
 					textPieces.add(new TextPieces.TextPiece(result, textPieces.getCurrentX(),
-					                                        textPieces.getCurrentX() + shift + width));
+					                                        textPieces.getCurrentX() + width));
                     textPieces.shiftCurrentX(shift);
 				}
 			}

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
@@ -20,6 +20,8 @@
  */
 package org.verapdf.gf.model.factory.chunks;
 
+import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
+
 import java.util.*;
 
 /**
@@ -80,6 +82,26 @@ public class TextPieces {
 		}
 		return ends;
 	}
+
+    public void addSpacesByShift(double threshold) {
+        List<TextPiece> spaces = new ArrayList<>();
+        Iterator<TextPiece> it = textPieces.iterator();
+        if (!it.hasNext()) {
+            return;
+        }
+        TextPiece prev = it.next();
+        double previousEnd = prev.getEndX();
+
+        while (it.hasNext()) {
+            TextPiece piece = it.next();
+            double currentStart = piece.getStartX();
+            if (currentStart - previousEnd > threshold) {
+                spaces.add(new TextPieces.TextPiece(" ", previousEnd, currentStart));
+            }
+            previousEnd = piece.getEndX();
+        }
+        textPieces.addAll(spaces);
+    }
 
 	public static class TextPiece {
 		private final String value;

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
@@ -35,6 +35,10 @@ public class TextPieces {
 		currentX = textPiece.endX;
 	}
 
+    public SortedSet<TextPiece> getTextPieces() {
+        return textPieces;
+    }
+
 	public String getValue() {
 		StringBuilder unicodeValue = new StringBuilder();
 		for (TextPiece textPiece : textPieces) {
@@ -91,6 +95,10 @@ public class TextPieces {
 		public double getEndX() {
 			return endX;
 		}
+
+        public double getStartX() {
+            return startX;
+        }
 	}
 
 	public static class TextPieceComparator implements Comparator<TextPiece> {

--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextPieces.java
@@ -20,8 +20,6 @@
  */
 package org.verapdf.gf.model.factory.chunks;
 
-import org.verapdf.wcag.algorithms.semanticalgorithms.utils.TextChunkUtils;
-
 import java.util.*;
 
 /**
@@ -36,10 +34,6 @@ public class TextPieces {
 		textPieces.add(textPiece);
 		currentX = textPiece.endX;
 	}
-
-    public SortedSet<TextPiece> getTextPieces() {
-        return textPieces;
-    }
 
 	public String getValue() {
 		StringBuilder unicodeValue = new StringBuilder();
@@ -83,17 +77,17 @@ public class TextPieces {
 		return ends;
 	}
 
-    public void addSpacesByShift(double threshold) {
+    public void addSpaces(double threshold) {
         List<TextPiece> spaces = new ArrayList<>();
-        Iterator<TextPiece> it = textPieces.iterator();
-        if (!it.hasNext()) {
+        Iterator<TextPiece> validation = textPieces.iterator();
+        if (!validation.hasNext()) {
             return;
         }
-        TextPiece prev = it.next();
+        TextPiece prev = validation.next();
         double previousEnd = prev.getEndX();
 
-        while (it.hasNext()) {
-            TextPiece piece = it.next();
+        while (validation.hasNext()) {
+            TextPiece piece = validation.next();
             double currentStart = piece.getStartX();
             if (currentStart - previousEnd > threshold) {
                 spaces.add(new TextPieces.TextPiece(" ", previousEnd, currentStart));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable spacing: spaces are now inserted in a separate pass using a font-size–based threshold.
  * Corrected placement so widths and end positions account for font size and horizontal scaling.

* **Refactor**
  * Simplified text-piece processing and bookkeeping so symbol boundaries and mappings align with width-based metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->