### PR TITLE
wcag/ChunkParser: scale Type3 glyph advances by /FontMatrix, not hardcoded 1/1000

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -38,6 +38,8 @@ import org.verapdf.pd.colors.PDDeviceRGB;
 import org.verapdf.pd.font.PDFontDescriptor;
 import org.verapdf.pd.images.PDXForm;
 import org.verapdf.pd.images.PDXObject;
+import org.verapdf.pd.font.PDFont;
+import org.verapdf.pd.font.type3.PDType3Font;
 import org.verapdf.pd.optionalcontent.PDOCMDDictionary;
 import org.verapdf.pd.optionalcontent.PDOptionalContentProperties;
 import org.verapdf.tools.StaticResources;
@@ -856,6 +858,7 @@ public class ChunkParser {
 	private void parseString(COSString string, TextPieces textPieces) {
 		byte[] bytes = string.get();
 		try (InputStream inputStream = new ByteArrayInputStream(bytes)) {
+			double glyphSpaceToTextSpace = getGlyphWidthToTextSpaceScale(graphicsState.getTextState().getTextFont());
 			while (inputStream.available() > 0) {
 				int code = graphicsState.getTextState().getTextFont().readCode(inputStream);
 				Double width = graphicsState.getTextState().getTextFont().getWidth(code);
@@ -868,7 +871,7 @@ public class ChunkParser {
 								graphicsState.getTextState().getWordSpacing() : 0)) *
 								graphicsState.getTextState().getHorizontalScaling();
                 width = width *
-                        graphicsState.getTextState().getTextFontSize() / 1000 *
+                        graphicsState.getTextState().getTextFontSize() * glyphSpaceToTextSpace *
                         graphicsState.getTextState().getHorizontalScaling();
                 String value = graphicsState.getTextState().getTextFont().toUnicode(code);
 				String result = value;
@@ -885,6 +888,16 @@ public class ChunkParser {
 		} catch (IOException e) {
 			LOGGER.log(Level.SEVERE, "Error processing text show operator's string argument : " + new String(bytes), e);
 		}
+	}
+
+		private static double getGlyphWidthToTextSpaceScale(PDFont font) {
+		if (font instanceof PDType3Font) {
+			double[] fontMatrix = ((PDType3Font) font).getFontMatrix();
+			if (fontMatrix != null && fontMatrix.length >= 1 && fontMatrix[0] != 0.0) {
+				return fontMatrix[0];
+			}
+		}
+		return 1.0 / 1000.0;
 	}
 
 	private TextChunk createTextChunk(List<COSBase> arguments, String operatorType, int operatorIndex) {


### PR DESCRIPTION
## Problem

`ChunkParser#parseString` computes each glyph's text-space advance as:

```java
width = width * getTextState().getTextFontSize() / 1000 * getTextState().getHorizontalScaling();
```

`PDFont#getWidth(code)` returns the raw `/Widths` value in the font's **glyph space**. For most fonts glyph space is 1/1000 text units, so dividing by 1000 is correct — but **Type3 fonts define their own glyph space via `/FontMatrix`**. For a Type3 font whose `/FontMatrix` is e.g. `[.0004883 0 0 -.0004883 0 0]` (= 1/2048), dividing by 1000 instead of by 2048 makes every advance ~2.048× too large, corrupting `TextPiece` end positions and the resulting text-chunk bounding boxes.

## Impact

Consumers of these metrics mis-assemble text. In opendataloader-pdf (which bundles this module), real-world Type3 PDFs drop a duplicate adjacent glyph and gain a spurious space — `1.66E-2` is extracted as `1. 6E-2`, `Programme` as `Progra me`. Downstream report: https://github.com/opendataloader-project/opendataloader-pdf/issues/578

This follows up #722 (which refactored this method but kept the hardcoded `/ 1000`); same spirit as veraPDF-parser #511 (CFF CID `FontMatrix`).

## Fix

Add a `getGlyphWidthToTextSpaceScale(PDFont)` helper that returns the horizontal `/FontMatrix` component (`fontMatrix[0]`) for a `PDType3Font` (null/length/zero-guarded), and the unchanged `1/1000` for every other font; the factor is hoisted out of the per-code loop. The `TJ`-array displacement path (`obj.getReal() / 1000`, which is text-space thousandths and font-independent) is intentionally left unchanged.

## Verification

- Compiles on the current `integration` branch (`mvn -pl wcag-validation -am compile`, BUILD SUCCESS).
- End-to-end through opendataloader-pdf 2.4.7 (which bundles `wcag-validation` 1.31.65) on a public real-world Type3 PDF (EPD epd28600): **before** → `1. 6E-2`, 34 spacing artifacts; **after** → `1.66E-2`, **0** artifacts. Same toolchain, only this patch toggled.
- Non-Type3 (Type1) PDFs produce byte-identical output — the `instanceof PDType3Font` guard leaves the default path untouched — and previously-correct values are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text glyph width calculation accuracy in PDF validation, particularly for Type3 fonts, resulting in more precise text positioning and rendering measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->