### PR TITLE
Add getL and getstreamLength methods to GFPDInlineImage

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
@@ -24,6 +24,7 @@
 package org.verapdf.gf.model.factory.operators;
 
 import org.verapdf.as.ASAtom;
+import org.verapdf.as.io.ASMemoryInStream;
 import org.verapdf.cos.*;
 import org.verapdf.gf.model.factory.colors.ColorSpaceFactory;
 import org.verapdf.gf.model.impl.containers.StaticContainers;
@@ -74,6 +75,7 @@ import org.verapdf.pdfa.flavours.PDFAFlavour;
 import org.verapdf.pdfa.flavours.PDFFlavours;
 import org.verapdf.tools.StaticResources;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.logging.*;
 
@@ -623,9 +625,15 @@ class OperatorParser {
 		    && (gs.isProcessColorOperators() || Boolean.TRUE.equals(imageParameters.getBooleanKey(ASAtom.IM)))) {
 
 			arguments.add(imageParameters);
-			processedOperators.add(new GFOp_BI(new ArrayList<>()));
+            long streamLength = 0;
+            try {
+                streamLength = ((ASMemoryInStream) rawOperator.getImageData()).getStreamLength();
+            } catch (IOException e) {
+                LOGGER.log(Level.SEVERE, "Error during computing inline image data stream length", e);
+            }
+            processedOperators.add(new GFOp_BI(new ArrayList<>()));
 			processedOperators.add(new GFOp_ID(arguments));
-			processedOperators.add(new GFOp_EI(arguments, resourcesHandler, gs.getFillColorSpace()));
+			processedOperators.add(new GFOp_EI(arguments, resourcesHandler, gs.getFillColorSpace(), streamLength));
 		}
 	}
 

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/operator/inlineimage/GFOp_EI.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/operator/inlineimage/GFOp_EI.java
@@ -43,12 +43,14 @@ public class GFOp_EI extends GFOpInlineImage implements Op_EI {
 
 	private final PDResourcesHandler resourcesHandler;
 	private final org.verapdf.pd.colors.PDColorSpace inheritedFillCS;
+    private final long dataStreamLength;
 
 	public GFOp_EI(List<COSBase> arguments, PDResourcesHandler resourcesHandler,
-				   org.verapdf.pd.colors.PDColorSpace inheritedFillCS) {
+				   org.verapdf.pd.colors.PDColorSpace inheritedFillCS, Long dataStreamLength) {
 		super(arguments, OP_EI_TYPE);
 		this.resourcesHandler = resourcesHandler;
 		this.inheritedFillCS = inheritedFillCS;
+        this.dataStreamLength = dataStreamLength;
 	}
 
 	@Override
@@ -63,7 +65,7 @@ public class GFOp_EI extends GFOpInlineImage implements Op_EI {
 		COSBase parameters = this.arguments.get(0);
 		org.verapdf.pd.images.PDInlineImage inlineImage =
 				new org.verapdf.pd.images.PDInlineImage(new COSObject(parameters),
-						resourcesHandler.getObjectResources(), resourcesHandler.getPageResources());
+						resourcesHandler.getObjectResources(), resourcesHandler.getPageResources(), dataStreamLength);
 		List<PDInlineImage> inlineImages = new ArrayList<>(MAX_NUMBER_OF_ELEMENTS);
 		inlineImages.add(new GFPDInlineImage(inlineImage, this.inheritedFillCS));
 		return Collections.unmodifiableList(inlineImages);

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/images/GFPDInlineImage.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/images/GFPDInlineImage.java
@@ -160,4 +160,14 @@ public class GFPDInlineImage extends GFPDResource implements PDInlineImage {
 	public Boolean getisMask() {
 		return false;
 	}
+
+    @Override
+    public Long getL() {
+        return ((org.verapdf.pd.images.PDInlineImage) this.simplePDObject).getL();
+    }
+
+    @Override
+    public Long getstreamLength() {
+        return ((org.verapdf.pd.images.PDInlineImage) this.simplePDObject).getStreamLength();
+    }
 }


### PR DESCRIPTION
update OperatorParser and GFOp_EI for rule 6.1.9-2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline image handling by preserving and exposing image data stream length.
  * Added fallback handling when stream length cannot be determined, preventing processing failures.
  * Ensured inline image metadata is consistently available through the validation model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->