### PR TITLE
Make null streamLength when catching exception

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/factory/operators/OperatorParser.java
@@ -625,11 +625,11 @@ class OperatorParser {
 		    && (gs.isProcessColorOperators() || Boolean.TRUE.equals(imageParameters.getBooleanKey(ASAtom.IM)))) {
 
 			arguments.add(imageParameters);
-            long streamLength = 0;
+            Long streamLength = null;
             try {
                 streamLength = ((ASMemoryInStream) rawOperator.getImageData()).getStreamLength();
             } catch (IOException e) {
-                LOGGER.log(Level.SEVERE, "Error during computing inline image data stream length", e);
+                LOGGER.log(Level.SEVERE, "Error during computing inline image data stream length");
             }
             processedOperators.add(new GFOp_BI(new ArrayList<>()));
 			processedOperators.add(new GFOp_ID(arguments));

--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/operator/inlineimage/GFOp_EI.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/operator/inlineimage/GFOp_EI.java
@@ -43,7 +43,7 @@ public class GFOp_EI extends GFOpInlineImage implements Op_EI {
 
 	private final PDResourcesHandler resourcesHandler;
 	private final org.verapdf.pd.colors.PDColorSpace inheritedFillCS;
-    private final long dataStreamLength;
+    private final Long dataStreamLength;
 
 	public GFOp_EI(List<COSBase> arguments, PDResourcesHandler resourcesHandler,
 				   org.verapdf.pd.colors.PDColorSpace inheritedFillCS, Long dataStreamLength) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline image processing when stream length cannot be determined.
  * Preserved unknown stream lengths instead of incorrectly defaulting them to zero.
  * Enhanced error handling during inline image parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->