### PR TITLE
Use isEquivalentTo instead of equals for tint and alternate in Separa…

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/colors/GFPDSeparation.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/colors/GFPDSeparation.java
@@ -84,7 +84,7 @@ public class GFPDSeparation extends GFPDColorSpace implements PDSeparation {
                 COSObject tintTransformCurrent =
                         ((org.verapdf.pd.colors.PDSeparation) simplePDObject).getCosTintTransform();
 
-                if (!alternateSpaceToCompare.equals(alternateSpaceCurrent) || !tintTransformToCompare.equals(tintTransformCurrent)) {
+                if (!alternateSpaceToCompare.isEquivalentTo(alternateSpaceCurrent) || !tintTransformToCompare.isEquivalentTo(tintTransformCurrent)) {
                     StaticContainers.getInconsistentSeparations().add(name);
                     return Boolean.FALSE;
                 }


### PR DESCRIPTION
…tion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency validation for separation colors by recognizing equivalent color definitions, reducing incorrect inconsistency reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->