### PR TITLE
Fix NPE in getobjectKey()

### DIFF
--- a/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDObject.java
+++ b/validation-model/src/main/java/org/verapdf/gf/model/impl/pd/GFPDObject.java
@@ -119,7 +119,8 @@ public class GFPDObject extends GenericModelObject implements PDObject {
 	
 	@Override
 	public String getobjectKey() {
-		return simpleCOSObject != null && !simpleCOSObject.empty() ? simpleCOSObject.getObjectKey().toString() : null;
+		return simpleCOSObject != null && !simpleCOSObject.empty() && simpleCOSObject.getObjectKey() != null
+                ? simpleCOSObject.getObjectKey().toString() : null;
 	}
 
 	@Override


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PDF objects without an object key, preventing errors when accessing their metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->