### PR TITLE
Do not scale TJ array adjustments by the Type 3 FontMatrix

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/ChunkParser.java
@@ -66,6 +66,13 @@ public class ChunkParser {
 	public static final String REPLACEMENT_CHARACTER_STRING = "\uFFFD";
     public static final Map<String, String> fontNameToFontFamilyMap = new HashMap<>();
 
+	/**
+	 * A number in a TJ array is expressed in thousandths of a unit of text space
+	 * (ISO 32000-1, 9.4.3). Unlike a glyph width, it is not a glyph space value,
+	 * so it is never scaled by the FontMatrix of a Type 3 font.
+	 */
+	private static final double TEXT_SPACE_UNIT = 1.0 / 1000.0;
+
 	private final Deque<GraphicsState> graphicsStateStack = new ArrayDeque<>();
 	private final Stack<Long> markedContentStack = new Stack<>();
     private final Stack<Boolean> visibleContentStack = new Stack<Boolean>();
@@ -842,7 +849,7 @@ public class ChunkParser {
 						parseString(isVertical, (COSString) obj.getDirectBase(), textPieces, scalingFactor);
 					} else if (obj.getType().isNumber()) {
 						TextState textState = graphicsState.getTextState();
-						textPieces.shiftCurrent(-obj.getReal() * scalingFactor * textState.getTextFontSize() * 
+						textPieces.shiftCurrent(-obj.getReal() * TEXT_SPACE_UNIT * textState.getTextFontSize() *
 								(isVertical ? 1 : textState.getHorizontalScaling()));
 					}
 				}


### PR DESCRIPTION
Fixes the reversed reading order reported in veraPDF/veraPDF-library#1623.

A number in a `TJ` array is expressed in thousandths of a unit of text space. It is a text space quantity and never passes through glyph space, so the font's `FontMatrix` must not be applied to it. A glyph *width* is a glyph space quantity and does need the `FontMatrix` — that part of #733 is correct and is left alone.

Because #733 applies the scaling factor to the whole text-showing argument, the `TJ` adjustments pick it up as well. For every non-Type 3 font `getHorizontalScalingFactor()` returns exactly `1.0/1000.0`, so nothing changes there. For a Type 3 font whose `FontMatrix` is not `[0.001 0 0 0.001 0 0]` the adjustments are off by the ratio between the two — a factor of 1000 for an identity matrix — which makes every glyph advance backwards and reverses the extracted text.

```diff
  } else if (obj.getType().isNumber()) {
      TextState textState = graphicsState.getTextState();
-     textPieces.shiftCurrent(-obj.getReal() * scalingFactor * textState.getTextFontSize() *
+     textPieces.shiftCurrent(-obj.getReal() * TEXT_SPACE_UNIT * textState.getTextFontSize() *
              (isVertical ? 1 : textState.getHorizontalScaling()));
  }
```

### Verification

[`repro-issueA-tj-reversal.pdf`](https://github.com/SangWJDev/veraPDF-validation/raw/repro-type3-fonts/repro-issueA-tj-reversal.pdf) is a 1.9 KB hand-written file with one Type 3 font, `/FontMatrix [1 0 0 1 0 0]`, and a `TJ` array with positive kerning between three glyphs.

| | result |
|---|---|
| poppler `pdftotext` | `ABC` |
| before | `CBA` |
| after | `ABC` |

On the real document this came from — a 156-page PowerPoint export with 156 Type 3 fonts — the extracted text goes from fully reversed to correct reading order. That document also hits the separate zero-`FontBBox` problem, so the end-to-end run there had both patches applied; the repro file above isolates this one.

For regression, I ran an 11-document corpus (roughly 1 400 pages, ordinary Type 0 / CIDFontType2 and Type 1 fonts) through the stock and patched builds. The 10 documents that do not use Type 3 fonts produced **byte-identical output**. That is expected rather than lucky: for every non-Type 3 font the factor being replaced is already exactly `1.0/1000.0`, so the change is an identity on that path.

Builds clean: `mvn -pl wcag-validation -am compile`.

**How the runtime numbers were produced**, so you can weigh them properly: the behavioural runs above were made with the equivalent one-line change applied to the v1.31.99 sources and the recompiled classes swapped into an opendataloader-pdf fat jar, since that is a build that can actually extract text end to end. The branch itself is against `integration` and was verified to compile there; the change is the same in both.

### Note

I could not add a regression test — `wcag-validation` has no `src/test` directory and I did not want to introduce a test module unprompted. If you would like the repro PDF committed as a fixture, tell me where it should go and I will add it with a test.
