### PR TITLE
Do not derive a zero text chunk height from an empty font bounding box

### DIFF
--- a/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
+++ b/wcag-validation/src/main/java/org/verapdf/gf/model/factory/chunks/TextChunksHelper.java
@@ -34,6 +34,13 @@ import java.util.List;
  */
 public class TextChunksHelper {
 
+	/**
+	 * Ascent and descent to assume, as a fraction of the em, when the font
+	 * provides no usable vertical metrics at all.
+	 */
+	private static final double FALLBACK_ASCENT = 0.8;
+	private static final double FALLBACK_DESCENT = -0.2;
+
 	protected static COSBase getArgument(List<COSBase> arguments, String operatorType) {
 		if (Operators.DOUBLE_QUOTE.equals(operatorType)) {
 			if (arguments.size() > 2) {
@@ -62,9 +69,20 @@ public class TextChunksHelper {
 		if (ascent == null) {
 			ascent = fontBoundingBox[3];
 		}
+		double horizontalScalingFactor = TextChunksHelper.getHorizontalScalingFactor(font);
+		double verticalScalingFactor = TextChunksHelper.getVerticalScalingFactor(font);
+		if (ascent == 0.0 && descent == 0.0) {
+			// A font bounding box whose elements are all zero carries no size information,
+			// and neither do an ascent and a descent that are both zero. Keeping those
+			// values would give every text chunk of this font a height of zero, which is
+			// indistinguishable from a genuinely invisible glyph. Assume a common em split
+			// instead. Dividing by the scaling factor expresses it in glyph space, so it
+			// holds for a Type 3 font with any FontMatrix as well.
+			ascent = FALLBACK_ASCENT / verticalScalingFactor;
+			descent = FALLBACK_DESCENT / verticalScalingFactor;
+		}
 		double x1;
 		double x2;
-		double horizontalScalingFactor = TextChunksHelper.getHorizontalScalingFactor(font);
 		if (textRenderingMatrixBefore.getScaleX() >= 0 && textRenderingMatrixBefore.getShearX() >= 0) {
 			x1 = textRenderingMatrixBefore.getTranslateX() + descent * textRenderingMatrixBefore.getShearX() * horizontalScalingFactor;
 			x2 = textRenderingMatrixAfter.getTranslateX() + ascent * textRenderingMatrixAfter.getShearX() * horizontalScalingFactor;
@@ -80,7 +98,6 @@ public class TextChunksHelper {
 		}
 		double y1;
 		double y2;
-		double verticalScalingFactor = TextChunksHelper.getVerticalScalingFactor(font);
 		if (textRenderingMatrixBefore.getScaleY() >= 0 && textRenderingMatrixBefore.getShearY() >= 0) {
 			y1 = textRenderingMatrixBefore.getTranslateY() + descent * textRenderingMatrixBefore.getScaleY() * verticalScalingFactor;
 			y2 = textRenderingMatrixAfter.getTranslateY() + ascent * textRenderingMatrixAfter.getScaleY() * verticalScalingFactor;


### PR DESCRIPTION
Fixes the silent text loss reported in veraPDF/veraPDF-library#1624.

When a font descriptor has no `/Ascent` and no `/Descent`, `calculateTextBoundingBoxH` takes the vertical extent from `/FontBBox`. A font bounding box whose four elements are all zero carries no size information, so this yields an ascent and a descent of zero and every text chunk of that font ends up with a height of exactly zero.

Nothing downstream can tell that apart from a glyph that really has no height. Consumers that discard tiny text then drop the whole document — in the case that led me here, a 156-page file extracted 0 characters with no exception, no warning and no log entry.

This falls back to a common em split when there are no usable vertical metrics at all:

```diff
+ double horizontalScalingFactor = TextChunksHelper.getHorizontalScalingFactor(font);
+ double verticalScalingFactor = TextChunksHelper.getVerticalScalingFactor(font);
+ if (ascent == 0.0 && descent == 0.0) {
+     ascent = FALLBACK_ASCENT / verticalScalingFactor;
+     descent = FALLBACK_DESCENT / verticalScalingFactor;
+ }
```

The two scaling-factor lookups move up to the top of the method so the fallback can use them; they are otherwise unchanged. Dividing by the vertical scaling factor expresses the values in glyph space, which keeps them correct for a Type 3 font with any `FontMatrix` as well as for ordinary fonts.

### The constants are a proposal, not a claim

`0.8` / `−0.2` is a widely used default, but I have no attachment to those numbers — the point of the patch is not to propagate a meaningless `0`. If you would rather

- derive the extent from the `d1` operands of the Type 3 `CharProcs`,
- use a different pair of defaults,
- or gate this behind a setting,

say so and I will rework it. I would also be glad to hear if you think the right fix belongs somewhere else entirely.

### Verification

[`repro-issueB-zero-fontbbox.pdf`](https://github.com/SangWJDev/veraPDF-validation/raw/repro-type3-fonts/repro-issueB-zero-fontbbox.pdf) is a 1.8 KB hand-written file: one Type 3 font with the conventional `/FontMatrix [0.001 0 0 0.001 0 0]`, `/FontBBox [0 0 0 0]` in both the font dictionary and the descriptor, no `/Ascent`, no `/Descent`, and a plain `Tj` with no kerning.

| | result |
|---|---|
| poppler `pdftotext` | `ABC` |
| before | empty output, 0 bytes |
| after | `ABC` |

On the 156-page document, extraction goes from 0 characters to 38 469 non-whitespace characters. That document also hits the separate `TJ` kerning problem, so the end-to-end run there had both patches applied; the repro file above isolates this one.

For regression, I ran an 11-document corpus (roughly 1 400 pages) through the stock and patched builds. The 10 documents that do not hit this path produced **byte-identical output** — the new branch is only reachable when a font supplies no usable vertical metrics at all.

Builds clean: `mvn -pl wcag-validation -am compile`.

**How the runtime numbers were produced**, so you can weigh them properly: the behavioural runs above were made with the equivalent change applied to the v1.31.99 sources and the recompiled classes swapped into an opendataloader-pdf fat jar, since that is a build that can actually extract text end to end. The branch itself is against `integration` and was verified to compile there; the change is the same in both.

### Note

I could not add a regression test — `wcag-validation` has no `src/test` directory and I did not want to introduce a test module unprompted. If you would like the repro PDF committed as a fixture, tell me where it should go and I will add it with a test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text bounding-box calculations for fonts with missing or unusable vertical metrics.
  * Added fallback font measurements to improve the positioning and sizing of horizontally rendered text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->